### PR TITLE
Refactor gateway contract to transfer protocol fee only if it is greater than zero and emit refund address instead of sender

### DIFF
--- a/contracts/Gateway.sol
+++ b/contracts/Gateway.sol
@@ -104,7 +104,7 @@ contract Gateway is IGateway, GatewaySettingManager, PausableUpgradeable {
 
 		// emit order created event
 		emit OrderCreated(
-			order[orderId].sender,
+			_refundAddress,
 			_token,
 			order[orderId].amount,
 			_protocolFee,
@@ -203,8 +203,10 @@ contract Gateway is IGateway, GatewaySettingManager, PausableUpgradeable {
 		require(!order[_orderId].isRefunded, 'OrderRefunded');
 		require(order[_orderId].protocolFee >= _fee, 'FeeExceedsProtocolFee');
 
-		// transfer refund fee to the treasury
-		IERC20(order[_orderId].token).transfer(treasuryAddress, _fee);
+		if (order[_orderId].protocolFee > 0) {
+			// transfer protocol fee
+			IERC20(order[_orderId].token).transfer(treasuryAddress, _fee);
+		}
 
 		// reset state values
 		order[_orderId].isRefunded = true;


### PR DESCRIPTION
This pull request refactors the gateway contract to improve the transfer of the protocol fee. Previously, the fee was transferred regardless of its value, but now it is only transferred if it is greater than zero. Additionally, the contract now emits the refund address instead of the sender in the OrderCreated event. These changes enhance the efficiency and accuracy of the gateway contract.