### PR TITLE
feat: add withdraw function to Gateway

### DIFF
--- a/contracts/Gateway.sol
+++ b/contracts/Gateway.sol
@@ -302,6 +302,19 @@ contract Gateway is IGateway, GatewaySettingManager, PausableUpgradeable {
 
         emit OrderSettledIn(_provider, _sender, _amount, _token, _orderId);
     }
+	/** @dev See {withdraw-IGateway} */
+	function withdraw(bytes memory _signature, address provider, address recipient, address _token, uint256 _amount) external isValidAmount(_amount) onlyAggregator returns (bool) {
+		bytes32 messageHash = keccak256(abi.encodePacked(provider, recipient, _token, _amount));
+		bytes32 ethSignedMessageHash = messageHash.toEthSignedMessageHash();
+		address signer = ethSignedMessageHash.recover(_signature);
+		require(signer == provider, 'InvalidSignature');
+
+		require(balance[_token][provider] >= _amount, 'InsufficientBalance');
+		balance[_token][provider] -= _amount;
+		IERC20(_token).transfer(recipient, _amount);
+		emit Withdraw(provider, recipient, _token, _amount);
+		return true;
+	}
 
 	/* ##################################################################
                                 VIEW CALLS

--- a/contracts/Gateway.sol
+++ b/contracts/Gateway.sol
@@ -302,7 +302,8 @@ contract Gateway is IGateway, GatewaySettingManager, PausableUpgradeable {
 
         emit OrderSettledIn(_provider, _sender, _amount, _token, _orderId);
     }
-	/** @dev See {withdraw-IGateway} */
+
+	/** @dev See {withdrawFrom-IGateway} */
 	function withdrawFrom(address provider, address recipient, uint256 _amount, address _token, bytes memory _signature) external isValidAmount(_amount) onlyAggregator returns (bool) {
 		bytes32 messageHash = keccak256(abi.encodePacked(provider, recipient, _amount, _token));
 		bytes32 ethSignedMessageHash = messageHash.toEthSignedMessageHash();

--- a/contracts/Gateway.sol
+++ b/contracts/Gateway.sol
@@ -303,8 +303,8 @@ contract Gateway is IGateway, GatewaySettingManager, PausableUpgradeable {
         emit OrderSettledIn(_provider, _sender, _amount, _token, _orderId);
     }
 	/** @dev See {withdraw-IGateway} */
-	function withdraw(bytes memory _signature, address provider, address recipient, address _token, uint256 _amount) external isValidAmount(_amount) onlyAggregator returns (bool) {
-		bytes32 messageHash = keccak256(abi.encodePacked(provider, recipient, _token, _amount));
+	function withdrawFrom(address provider, address recipient, uint256 _amount, address _token, bytes memory _signature) external isValidAmount(_amount) onlyAggregator returns (bool) {
+		bytes32 messageHash = keccak256(abi.encodePacked(provider, recipient, _amount, _token));
 		bytes32 ethSignedMessageHash = messageHash.toEthSignedMessageHash();
 		address signer = ethSignedMessageHash.recover(_signature);
 		require(signer == provider, 'InvalidSignature');
@@ -312,7 +312,7 @@ contract Gateway is IGateway, GatewaySettingManager, PausableUpgradeable {
 		require(balance[_token][provider] >= _amount, 'InsufficientBalance');
 		balance[_token][provider] -= _amount;
 		IERC20(_token).transfer(recipient, _amount);
-		emit Withdraw(provider, recipient, _token, _amount);
+		emit Withdrawn(provider, recipient, _amount, _token);
 		return true;
 	}
 

--- a/contracts/interfaces/IGateway.sol
+++ b/contracts/interfaces/IGateway.sol
@@ -75,6 +75,14 @@ interface IGateway {
 	 * @param orderId The ID of the order.
 	 */
 	event OrderSettledIn(address indexed provider, address indexed senderAddress, uint256 indexed amount, address token, bytes32 orderId);
+	 * @notice Emitted when a withdrawal is made by a provider.
+	 * @param provider The address of the provider.
+	 * @param sender The address of the sender.
+	 * @param token The address of the withdrawn token.
+	 * @param amount The amount of the withdrawal.
+	 */
+	event Withdraw(address indexed provider, address indexed sender, address indexed token, uint256 amount);
+
 	/* ##################################################################
                                 STRUCTS
     ################################################################## */
@@ -204,6 +212,19 @@ interface IGateway {
         address _token,
         uint256 _amount
     ) external;
+
+	/**
+	 * @notice Withdraws an asset from Gateway.
+	 * @dev Requirements:
+	 * - The provider must have enough balance.
+	 * @param _signature The signature of the provider.
+	 * @param _provider The address of the provider.
+	 * @param _recipient The address of the recipient.
+	 * @param _token The address of the asset.
+	 * @param _amount The amount to be withdrawn.
+	 * @return bool The withdrawal is successful.
+	 */
+	function withdraw(bytes memory _signature, address _provider, address _recipient, address _token, uint256 _amount) external returns (bool);
 
 	/**
 	 * @notice Checks if a token is supported by Gateway.

--- a/contracts/interfaces/IGateway.sol
+++ b/contracts/interfaces/IGateway.sol
@@ -75,6 +75,8 @@ interface IGateway {
 	 * @param orderId The ID of the order.
 	 */
 	event OrderSettledIn(address indexed provider, address indexed senderAddress, uint256 indexed amount, address token, bytes32 orderId);
+
+	/**
 	 * @notice Emitted when a withdrawal is made by a provider.
 	 * @param provider The address of the provider.
 	 * @param sender The address of the sender.

--- a/contracts/interfaces/IGateway.sol
+++ b/contracts/interfaces/IGateway.sol
@@ -78,10 +78,10 @@ interface IGateway {
 	 * @notice Emitted when a withdrawal is made by a provider.
 	 * @param provider The address of the provider.
 	 * @param sender The address of the sender.
-	 * @param token The address of the withdrawn token.
 	 * @param amount The amount of the withdrawal.
+	 * @param token The address of the withdrawn token.
 	 */
-	event Withdraw(address indexed provider, address indexed sender, address indexed token, uint256 amount);
+	event Withdrawn(address indexed provider, address indexed sender, uint256 amount, address indexed token);
 
 	/* ##################################################################
                                 STRUCTS
@@ -217,14 +217,14 @@ interface IGateway {
 	 * @notice Withdraws an asset from Gateway.
 	 * @dev Requirements:
 	 * - The provider must have enough balance.
-	 * @param _signature The signature of the provider.
 	 * @param _provider The address of the provider.
 	 * @param _recipient The address of the recipient.
-	 * @param _token The address of the asset.
 	 * @param _amount The amount to be withdrawn.
+	 * @param _token The address of the asset.
+	 * @param _signature The signature of the provider.
 	 * @return bool The withdrawal is successful.
 	 */
-	function withdraw(bytes memory _signature, address _provider, address _recipient, address _token, uint256 _amount) external returns (bool);
+	function withdrawFrom(address _provider, address _recipient, uint256 _amount, address _token, bytes memory _signature) external returns (bool);
 
 	/**
 	 * @notice Checks if a token is supported by Gateway.

--- a/test/gateway/gateway.settleOrderOut.test.js
+++ b/test/gateway/gateway.settleOrderOut.test.js
@@ -154,7 +154,7 @@ describe("Gateway offramp order", function () {
 		)
 			.to.emit(gateway, Events.Gateway.OrderCreated)
 			.withArgs(
-				this.sender.address,
+				this.alice.address,
 				mockUSDT.address,
 				this.orderAmount,
 				this.protocolFee,
@@ -264,7 +264,7 @@ describe("Gateway offramp order", function () {
 		)
 			.to.emit(gateway, Events.Gateway.OrderCreated)
 			.withArgs(
-				this.sender.address,
+				this.alice.address,
 				mockUSDT.address,
 				this.orderAmount,
 				this.protocolFee,

--- a/test/gateway/gateway.withdraw.test.js
+++ b/test/gateway/gateway.withdraw.test.js
@@ -89,8 +89,8 @@ describe("Gateway Provider withdraw", function () {
     it("Should withdraw successfully with valid signature", async function () {
         const amount = ethers.utils.parseEther("1000");
         const messageHash = ethers.utils.solidityKeccak256(
-            ["address", "address", "address", "uint256"],
-            [this.alice.address, this.bob.address, this.mockUSDT.address, amount]
+            ["address", "address", "uint256", "address",],
+            [this.alice.address, this.bob.address, amount, this.mockUSDT.address]
         );
         const signature = await this.alice.signMessage(ethers.utils.arrayify(messageHash));
 
@@ -123,10 +123,10 @@ describe("Gateway Provider withdraw", function () {
         await expect(
             this.gateway
                 .connect(this.aggregator)
-                .withdraw(signature, this.alice.address, this.bob.address, this.mockUSDT.address, amount)
+                .withdrawFrom(this.alice.address, this.bob.address, amount, this.mockUSDT.address, signature)
         )
-            .to.emit(this.gateway, Events.Gateway.Withdraw)
-            .withArgs(this.alice.address, this.bob.address, this.mockUSDT.address, amount);
+            .to.emit(this.gateway, Events.Gateway.Withdrawn)
+            .withArgs(this.alice.address, this.bob.address, amount, this.mockUSDT.address);
 
         await assertDepositBalance(
             this.gateway,
@@ -140,7 +140,7 @@ describe("Gateway Provider withdraw", function () {
     it("Should fail with invalid signature", async function () {
         const amount = ethers.utils.parseEther("1000");
         const messageHash = ethers.utils.solidityKeccak256(
-            ["address", "address", "address", "uint256"],
+            ["address", "address", "uint256", "address"],
             [this.alice.address, this.bob.address, this.mockUSDT.address, amount]
         );
         const ethSignedMessageHash = ethers.utils.hashMessage(messageHash);
@@ -161,22 +161,22 @@ describe("Gateway Provider withdraw", function () {
         await expect(
             this.gateway
                 .connect(this.aggregator)
-                .withdraw(invalidSignature, this.alice.address, this.bob.address, this.mockUSDT.address, amount)
+                .withdrawFrom( this.alice.address, this.bob.address, amount, this.mockUSDT.address, invalidSignature)
         ).to.be.revertedWith("InvalidSignature");
     });
 
     it("Should fail with insufficient balance", async function () {
         const amount = ethers.utils.parseEther("1000");
         const messageHash = ethers.utils.solidityKeccak256(
-            ["address", "address", "address", "uint256"],
-            [this.alice.address, this.bob.address, this.mockUSDT.address, amount]
+            ["address", "address", "uint256", "address"],
+            [this.alice.address, this.bob.address, amount, this.mockUSDT.address]
         );
         const signature = await this.alice.signMessage(ethers.utils.arrayify(messageHash));
 
         await expect(
             this.gateway
                 .connect(this.aggregator)
-                .withdraw(signature, this.alice.address, this.bob.address, this.mockUSDT.address, amount)
+                .withdrawFrom(this.alice.address, this.bob.address, amount, this.mockUSDT.address, signature)
         ).to.be.revertedWith("InsufficientBalance");
     });
 
@@ -192,7 +192,7 @@ describe("Gateway Provider withdraw", function () {
         await expect(
             this.gateway
                 .connect(this.alice)
-                .withdraw(signature, this.alice.address, this.bob.address, this.mockUSDT.address, amount)
+                .withdrawFrom(this.alice.address, this.bob.address, amount, this.mockUSDT.address, signature)
         ).to.be.revertedWith("OnlyAggregator");
     });
 });

--- a/test/gateway/gateway.withdraw.test.js
+++ b/test/gateway/gateway.withdraw.test.js
@@ -1,0 +1,198 @@
+const { ethers } = require("hardhat");
+const { BigNumber } = require("@ethersproject/bignumber");
+
+const { gatewayFixture } = require("../fixtures/gateway.js");
+
+const {
+    deployContract,
+    ZERO_AMOUNT,
+    Errors,
+    Events,
+    mockMintDeposit,
+    assertBalance,
+    assertDepositBalance,
+} = require("../utils/utils.manager.js");
+const { expect } = require("chai");
+
+describe("Gateway Provider withdraw", function () {
+    beforeEach(async function () {
+        [
+            this.deployer,
+            this.treasuryAddress,
+            this.aggregator,
+            this.alice,
+            this.bob,
+            this.Eve,
+            this.hacker,
+            ...this.accounts
+        ] = await ethers.getSigners();
+
+        ({ gateway, mockUSDT } = await gatewayFixture());
+
+        this.mockDAI = await deployContract("MockUSDT");
+
+        this.mockUSDT = mockUSDT;
+        this.gateway = gateway;
+
+        this.depositAmount = ethers.utils.parseEther("1000000");
+
+        await mockMintDeposit(gateway, this.alice, mockUSDT, this.depositAmount);
+        await mockMintDeposit(gateway, this.bob, mockUSDT, this.depositAmount);
+        await mockMintDeposit(gateway, this.Eve, mockUSDT, this.depositAmount);
+        await mockMintDeposit(
+            gateway,
+            this.alice,
+            this.mockDAI,
+            this.depositAmount
+        );
+        await mockMintDeposit(gateway, this.bob, this.mockDAI, this.depositAmount);
+        await mockMintDeposit(gateway, this.Eve, this.mockDAI, this.depositAmount);
+
+        await assertBalance(
+            this.mockUSDT,
+            this.mockDAI,
+            this.alice.address,
+            this.depositAmount
+        );
+        await assertBalance(
+            this.mockUSDT,
+            this.mockDAI,
+            this.bob.address,
+            this.depositAmount
+        );
+        await assertBalance(
+            this.mockUSDT,
+            this.mockDAI,
+            this.Eve.address,
+            this.depositAmount
+        );
+
+        const token = ethers.utils.formatBytes32String("token");
+
+        await expect(
+            this.gateway
+                .connect(this.deployer)
+                .settingManagerBool(token, this.mockUSDT.address, BigNumber.from(1))
+        )
+            .to.emit(this.gateway, Events.Gateway.SettingManagerBool)
+            .withArgs(token, this.mockUSDT.address, BigNumber.from(1));
+
+        const aggregator = ethers.utils.formatBytes32String("aggregator");
+
+		await expect(
+			gateway
+				.connect(this.deployer)
+				.updateProtocolAddress(aggregator, this.aggregator.address)
+		).to.emit(gateway, Events.Gateway.ProtocolAddressUpdated);
+    });
+
+    it("Should withdraw successfully with valid signature", async function () {
+        const amount = ethers.utils.parseEther("1000");
+        const messageHash = ethers.utils.solidityKeccak256(
+            ["address", "address", "address", "uint256"],
+            [this.alice.address, this.bob.address, this.mockUSDT.address, amount]
+        );
+        const signature = await this.alice.signMessage(ethers.utils.arrayify(messageHash));
+
+        await assertDepositBalance(
+            this.gateway,
+            this.mockUSDT.address,
+            this.alice.address,
+            ZERO_AMOUNT
+        );
+
+        await expect(
+            this.gateway
+                .connect(this.alice)
+                .deposit(this.mockUSDT.address, this.depositAmount)
+        )
+            .to.emit(this.gateway, Events.Gateway.Deposit)
+            .withArgs(
+                this.alice.address,
+                this.mockUSDT.address,
+                BigNumber.from(this.depositAmount)
+            );
+
+        await assertDepositBalance(
+            this.gateway,
+            this.mockUSDT.address,
+            this.alice.address,
+            this.depositAmount
+        );
+
+        await expect(
+            this.gateway
+                .connect(this.aggregator)
+                .withdraw(signature, this.alice.address, this.bob.address, this.mockUSDT.address, amount)
+        )
+            .to.emit(this.gateway, Events.Gateway.Withdraw)
+            .withArgs(this.alice.address, this.bob.address, this.mockUSDT.address, amount);
+
+        await assertDepositBalance(
+            this.gateway,
+            this.mockUSDT.address,
+            this.alice.address,
+            this.depositAmount.sub(amount)
+        );
+
+    });
+
+    it("Should fail with invalid signature", async function () {
+        const amount = ethers.utils.parseEther("1000");
+        const messageHash = ethers.utils.solidityKeccak256(
+            ["address", "address", "address", "uint256"],
+            [this.alice.address, this.bob.address, this.mockUSDT.address, amount]
+        );
+        const ethSignedMessageHash = ethers.utils.hashMessage(messageHash);
+        const invalidSignature = await this.bob.signMessage(ethers.utils.arrayify(ethSignedMessageHash));
+
+        await expect(
+            this.gateway
+                .connect(this.alice)
+                .deposit(this.mockUSDT.address, this.depositAmount)
+        )
+            .to.emit(this.gateway, Events.Gateway.Deposit)
+            .withArgs(
+                this.alice.address,
+                this.mockUSDT.address,
+                BigNumber.from(this.depositAmount)
+            );
+            
+        await expect(
+            this.gateway
+                .connect(this.aggregator)
+                .withdraw(invalidSignature, this.alice.address, this.bob.address, this.mockUSDT.address, amount)
+        ).to.be.revertedWith("InvalidSignature");
+    });
+
+    it("Should fail with insufficient balance", async function () {
+        const amount = ethers.utils.parseEther("1000");
+        const messageHash = ethers.utils.solidityKeccak256(
+            ["address", "address", "address", "uint256"],
+            [this.alice.address, this.bob.address, this.mockUSDT.address, amount]
+        );
+        const signature = await this.alice.signMessage(ethers.utils.arrayify(messageHash));
+
+        await expect(
+            this.gateway
+                .connect(this.aggregator)
+                .withdraw(signature, this.alice.address, this.bob.address, this.mockUSDT.address, amount)
+        ).to.be.revertedWith("InsufficientBalance");
+    });
+
+    it("Should fail when called by non-aggregator", async function () {
+        const amount = ethers.utils.parseEther("1000");
+        const messageHash = ethers.utils.solidityKeccak256(
+            ["address", "address", "address", "uint256"],
+            [this.alice.address, this.bob.address, this.mockUSDT.address, amount]
+        );
+        const ethSignedMessageHash = ethers.utils.hashMessage(messageHash);
+        const signature = await this.alice.signMessage(ethers.utils.arrayify(ethSignedMessageHash));
+
+        await expect(
+            this.gateway
+                .connect(this.alice)
+                .withdraw(signature, this.alice.address, this.bob.address, this.mockUSDT.address, amount)
+        ).to.be.revertedWith("OnlyAggregator");
+    });
+});

--- a/test/utils/utils.manager.js
+++ b/test/utils/utils.manager.js
@@ -36,7 +36,7 @@ const Events = {
 		ProtocolAddressUpdated: "ProtocolAddressUpdated",
 		Deposit: "Deposit",
 		OrderSettledIn: "OrderSettledIn",
-		Withdraw: "Withdraw",
+		Withdrawn: "Withdrawn",
 	},
 };
 

--- a/test/utils/utils.manager.js
+++ b/test/utils/utils.manager.js
@@ -36,6 +36,7 @@ const Events = {
 		ProtocolAddressUpdated: "ProtocolAddressUpdated",
 		Deposit: "Deposit",
 		OrderSettledIn: "OrderSettledIn",
+		Withdraw: "Withdraw",
 	},
 };
 


### PR DESCRIPTION
This pull request adds a new function called `withdraw` to the `Gateway` contract. The function allows a provider to withdraw an asset from the Gateway. The function requires a valid signature from the provider and checks if the provider has enough balance. If the conditions are met, the function transfers the specified amount of the asset to the recipient address and emits a `Withdraw` event. The pull request also includes tests for the new functionality.