### PR TITLE
feat: Add OSS templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,34 +1,31 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+about: Report a bug to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ""
 ---
 
-**User Story**
-> Add the details of this issue from the user's POV
+**Describe the bug**
+A clear and concise description of what the bug is.
 
-**Acceptance Criteria(s)**
-> 1. **GIVEN** Given that something happens
-> **WHEN** Under certain conditions
-> **THEN** Then we expect a particular result
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
 
-**Tech Details**
->Technical changes that will happen include UI changes, styling updates, integration requirements
-* **UI State Changes:**
-    >  Changes to the frontend interface
-* **Styling Updates:**
-    >  CSS changes for the application
-* **Integration Requirements:**
-    >  Changes to the logic parts of the application or protocol 
+**Expected behavior**
+A clear and concise description of what you expected to happen.
 
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
 
-**Design Link**
->* Link to the figma design file 
+**Environment:**
+- OS: [e.g., Windows 10, macOS Ventura]
+- Browser: [e.g., Chrome 112]
+- Version: [e.g., 22.5]
 
-**Notes/Assumptions**
->* Notes or assumption that has to remain constant. 
-
-**Open Questions**
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**User Story**
+> Add the details of this issue from the user's POV
+
+**Acceptance Criteria(s)**
+> 1. **GIVEN** Given that something happens
+> **WHEN** Under certain conditions
+> **THEN** Then we expect a particular result
+
+**Tech Details**
+>Technical changes that will happen include UI changes, styling updates, integration requirements
+* **UI State Changes:**
+    >  Changes to the frontend interface
+* **Styling Updates:**
+    >  CSS changes for the application
+* **Integration Requirements:**
+    >  Changes to the logic parts of the application or protocol 
+
+
+**Design Link**
+>* Link to the figma design file 
+
+**Notes/Assumptions**
+>* Notes or assumption that has to remain constant. 
+
+**Open Questions**

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -6,10 +6,11 @@ labels: ''
 assignees: ''
 ---
 
+
 **User Story**
 > Add the details of this issue from the user's POV
 
-**Acceptance Criteria(s)**
+**Acceptance Criteria**
 > 1. **GIVEN** Given that something happens
 > **WHEN** Under certain conditions
 > **THEN** Then we expect a particular result

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: New feature for this project
+title: ''
+labels: ''
+assignees: ''
+---
+
+**User Story**
+> Add the details of this issue from the user's POV
+
+**Acceptance Criteria(s)**
+> 1. **GIVEN** Given that something happens
+> **WHEN** Under certain conditions
+> **THEN** Then we expect a particular result
+
+**Tech Details**
+>Technical changes that will happen include UI changes, styling updates, integration requirements
+* **UI State Changes:**
+    >  Changes to the frontend interface
+* **Styling Updates:**
+    >  CSS changes for the application
+* **Integration Requirements:**
+    >  Changes to the logic parts of the application or protocol 
+
+
+**Design Link**
+>* Link to the figma design file 
+
+**Notes/Assumptions**
+>* Notes or assumption that has to remain constant. 
+
+**Open Questions**

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "General Support"
+    url: "https://paycrest.io/"
+    about: "For general inquiries, visit our support page."

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: "General Support"
-    url: "https://paycrest.io/"
+    url: "mailto:devs@paycrest.io"
     about: "For general inquiries, visit our support page."

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://www.notion.so/paycrest/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c?pvs=4). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.
+By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.
 
 ### Description
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://www.notion.so/paycrest/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c?pvs=4). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.
+
+### Description
+
+> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
+>
+> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, contracts etc.
+>
+> If the UI is being changed, please provide screenshots.
+
+
+### References
+
+> Include any links supporting this change such as a:
+>
+> - GitHub Issue/PR number addressed or fixed
+> - StackOverflow post
+> - Support forum thread
+> - Related pull requests/issues from other repos
+>
+> If there are no references, simply delete this section.
+
+### Testing
+
+> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this project has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
+>
+> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
+>
+> Also include details of the environment this PR was developed in (language/platform/browser version).
+
+- [ ] This change adds test coverage for new/changed/fixed functionality
+
+### Checklist
+
+- [ ] I have added documentation for new/changed functionality in this PR
+- [ ] All active GitHub checks for tests, formatting, and security are passing
+- [ ] The correct base branch is being used, if not `master`


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://www.notion.so/paycrest/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c?pvs=4). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.

### Description

> New OSS templates for contributors

### References

> N/A

### Testing

> Go in to the `.github` folder to check if the templates cover the necessary use-case.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`